### PR TITLE
From simplecov: uncovered method seemingly isn't called

### DIFF
--- a/lib/prop_check/property/check_evaluator.rb
+++ b/lib/prop_check/property/check_evaluator.rb
@@ -27,7 +27,6 @@ module PropCheck
         end
       end
 
-      # :nocov:
       # SimpleCov seems to be having problems with `method_missing`
       # An issue has been made; see https://github.com/colszowka/simplecov/issues/728
       # Rest assured: these two methods are _definitely_ being called,
@@ -37,6 +36,10 @@ module PropCheck
       # Dispatches to caller whenever something is not part of `bindings`.
       # (No need to invoke this method manually)
       def method_missing(method, *args, &block)
+        puts "-" * 80
+        puts "such calling many wow"
+        raise "not called"
+
         super || @caller.__send__(method, *args, &block)
       end
 
@@ -44,9 +47,12 @@ module PropCheck
       # Checks respond_to of caller whenever something is not part of `bindings`.
       # (No need to invoke this method manually)
       def respond_to_missing?(*args)
+        puts "-" * 80
+        puts "such calling many wow"
+        raise "not called"
+
         super || @caller.respond_to?(*args)
       end
-      # :nocov
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require 'simplecov'
+puts "starting simplecov"
 SimpleCov.start
 
 require "prop_check"


### PR DESCRIPTION
:wave: 

Hi first thanks for opening an issue, thanks for writing a PBT library in Ruby (I recently wrote a PBT post also complaining there is nothing fully fledged in ruby :grin: ) also iirc I recognize you from elixir forum :wave: 

Anyhow, I come here from https://github.com/colszowka/simplecov/issues/728 - I tried to reproduce the problem but running the tests locally I can't get those methods to be called. I was wary that you might catch input somewhere so I even added raises. Tests still pass for me.

Maybe I did something really stupid but to me it seems simplecov is right here and this is not called.

Cheers,
Tobi