### PR TITLE
Add generators for dates/date_times/times

### DIFF
--- a/lib/prop_check/generators.rb
+++ b/lib/prop_check/generators.rb
@@ -594,7 +594,7 @@ module PropCheck
     # DateTimes start around the year 2022 and deviate more when `size` increases.
     #
     #   >> Generators.date_times.sample(2, rng: Random.new(42))
-    #   => [#<DateTime: 2018-04-29T14:42:07+00:00 ((2458238j,52927s,0n),+0s,2299161j)>, #<DateTime: 2032-07-26T18:22:10+00:00 ((2463440j,66130s,0n),+0s,2299161j)>]
+    #   => [DateTime.new(2018, 4, 29, 14, 42, 7), DateTime.new(2032, 7, 26, 18, 22, 10)]
     def date_times
       date_time_vals.map { |values| DateTime.new(*values) }
     end
@@ -604,7 +604,7 @@ module PropCheck
     # Times start around the year 2022 and deviate more when `size` increases.
     #
     #   >> PropCheck::Generators.times.sample(2, rng: Random.new(42))
-    #   => [2018-04-29 14:42:07 +0200, 2032-07-26 18:22:10 +0200]
+    #   => [Time.new(2018, 4, 29, 14, 42, 7), Time.new(2032, 7, 26, 18, 22, 10)]
     def times
       date_time_vals.map { |values| Time.new(*values) }
     end
@@ -614,7 +614,7 @@ module PropCheck
     # Dates start around the year 2022 and deviate more when `size` increases.
     #
     #   >> Generators.dates.sample(2, rng: Random.new(42))
-    #   => [#<Date: 2018-04-29 ((2458238j,0s,0n),+0s,2299161j)>, #<Date: 2026-11-08 ((2461353j,0s,0n),+0s,2299161j)>]
+    #   => [Date.new(2018, 4, 29), Date.new(2026, 11, 8)]
     def dates
       date_vals.map { |values| Date.new(*values) }
     end

--- a/lib/prop_check/generators.rb
+++ b/lib/prop_check/generators.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
 
+require 'date'
 require 'prop_check/generator'
 require 'prop_check/lazy_tree'
 module PropCheck
@@ -586,6 +587,49 @@ module PropCheck
     #    => [9, 10, 8, 0, 10, -3, -8, 10, 1, -9, -10, nil, 1, 6, nil, 1, 9, -8, 8, 10]
     def nillable(other_generator)
       frequency(9 => other_generator, 1 => constant(nil))
+    end
+
+    ##
+    # Generates DateTimes.
+    # DateTimes start around the year 2022 and deviate more when `size` increases.
+    #
+    #   >> Generators.date_times.sample(2, rng: Random.new(42))
+    #   => [#<DateTime: 2018-04-29T14:42:07+00:00 ((2458238j,52927s,0n),+0s,2299161j)>, #<DateTime: 2032-07-26T18:22:10+00:00 ((2463440j,66130s,0n),+0s,2299161j)>]
+    def date_times
+      date_time_vals.map { |values| DateTime.new(*values) }
+    end
+
+    ##
+    # Generates Times.
+    # Times start around the year 2022 and deviate more when `size` increases.
+    #
+    #   >> PropCheck::Generators.times.sample(2, rng: Random.new(42))
+    #   => [2018-04-29 14:42:07 +0200, 2032-07-26 18:22:10 +0200]
+    def times
+      date_time_vals.map { |values| Time.new(*values) }
+    end
+
+    ##
+    # Generates Dates.
+    # Dates start around the year 2022 and deviate more when `size` increases.
+    #
+    #   >> Generators.dates.sample(2, rng: Random.new(42))
+    #   => [#<Date: 2018-04-29 ((2458238j,0s,0n),+0s,2299161j)>, #<Date: 2026-11-08 ((2461353j,0s,0n),+0s,2299161j)>]
+    def dates
+      date_vals.map { |values| Date.new(*values) }
+    end
+
+    private def date_vals
+      tuple(
+        integer.map { |i| i + 2022 },
+        choose(1..12),
+        choose(1..31)
+      ).where { |date_tuple| Date.valid_date?(*date_tuple) }
+    end
+
+    private def date_time_vals
+      time_vals = tuple(choose(0..23), choose(0..59), choose(0..59))
+      tuple(date_vals, time_vals).map { |date, time| date + time }
     end
 
     ##

--- a/spec/prop_check/generators_spec.rb
+++ b/spec/prop_check/generators_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe PropCheck::Generators do
+  describe '#dates' do
+    subject(:dates) { described_class.dates }
+
+    it 'produces valid dates' do
+      PropCheck.forall(dates) do |date|
+        expect(date).to be_a(Date)
+      end
+    end
+  end
+
+  describe '#times' do
+    subject(:times) { described_class.times }
+
+    it 'produces valid times' do
+      PropCheck.forall(times) do |time|
+        expect(time).to be_a(Time)
+      end
+    end
+  end
+
+  describe '#date_times' do
+    subject(:date_times) { described_class.date_times }
+
+    it 'produces valid date_times' do
+      PropCheck.forall(date_times) do |date_time|
+        expect(date_time).to be_a(DateTime)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds generators for `Date`, `DateTime` and `Time` types. They start with a year offset of 2022 (constant so it does not break on new years eve). 