### PR TITLE
Fix `PropCheck::Helper#call_splatted`

### DIFF
--- a/lib/prop_check/helper.rb
+++ b/lib/prop_check/helper.rb
@@ -33,12 +33,9 @@ module PropCheck
     end
 
     def call_splatted(val, &block)
-      case val
-      when Hash
-        block.call(**val)
-      else
-        block.call(val)
-      end
+      return block.call(**val) if val.is_a?(Hash) && val.keys.all? { |k| k.is_a?(Symbol) }
+
+      block.call(val)
       # if kwval != {}
       #   block.call(**kwval)
       # else

--- a/spec/prop_check_spec.rb
+++ b/spec/prop_check_spec.rb
@@ -249,5 +249,14 @@ RSpec.describe PropCheck do
       end
     end
 
+    describe 'generating a hash' do
+      include PropCheck::Generators
+
+      it 'does not fail wenn calling call_splatted' do
+        PropCheck.forall(hash_of(string, integer)) do |h|
+          expect(h).to be_a(Hash)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes an issue where a generated value from a hash generator, where one or more of the keys is not a symbol, was used as kwargs.

What failed: `forall(hash_of(string, integer)) do ...` 
Because in `call_splatted`
```rb
    def call_splatted(val, &block)
      case val
      when Hash
        block.call(**val) # <-- This branch would be taken, causing a TypeError
      else
        block.call(val)
      end
```
