### PR TITLE
Preserve backward compatibility with Ruby 2.5

### DIFF
--- a/lib/prop_check/generators.rb
+++ b/lib/prop_check/generators.rb
@@ -298,7 +298,7 @@ module PropCheck
         arr = []
         uniques = Set.new
         count = 0
-        (0..).lazy.map do
+        0.step.each.lazy.map do
           elem = element_generator.clone.generate(**kwargs)
           if uniques.add?(uniq_fun.call(elem.root))
             arr.push(elem)


### PR DESCRIPTION
Endless range is only available for Ruby >= 2.6