### PR TITLE
Configurable resize for properties as a whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 0.16.0
+  - Features:
+    - New option in `PropCheck::Property::Configuration` to resize all generators at once.
+    - Wrapper functions to modify this easily in `PropCheck::Property` called `#resize`, `#grow_fast`, `#grow_slowly`, `#grow_exponentially`, `#grow_quadratically`, `#grow_logarithmically`.
 - 0.15.0
   - Features:
     - Generators for `Date`, `Time` and `DateTime`.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ The value(s) generated from the generator(s) passed to the `forall` will be give
 Raise an exception from the block if there is a problem. If there is no problem, just return normally.
 
 ```ruby
-include PropCheck::Generators
+G = PropCheck::Generators
 # testing that Enumerable#sort sorts in ascending order
-PropCheck.forall(array(integer)) do |numbers|
+PropCheck.forall(G.array(G.integer)) do |numbers|
   sorted_numbers = numbers.sort
   
   # Check that no number is smaller than the previous number
@@ -124,8 +124,8 @@ end
 ```
 ```ruby
 # And then in a test case:
-include PropCheck::Generators
-PropCheck.forall(numbers: array(integer)) do |numbers:|
+G = PropCheck::Generators
+PropCheck.forall(numbers: G.array(G.integer)) do |numbers:|
   result = naive_average(numbers)
   unless result.is_a?(Integer) do
     raise "Expected the average to be an integer!"
@@ -135,10 +135,10 @@ end
 # Or if you e.g. are using RSpec:
 describe "#naive_average" do
   include PropCheck
-  include PropCheck::Generators
+  G = PropCheck::Generators
 
   it "returns an integer for any input" do
-    forall(numbers: array(integer)) do |numbers:|
+    forall(numbers: G.array(G.integer)) do |numbers:|
       result = naive_average(numbers)      
       expect(result).to be_a(Integer)
     end
@@ -208,11 +208,12 @@ It contains generators for:
 - (any, only real-valued) floats, 
 - (any, printable only, alphanumeric only, etc) strings and symbols
 - fixed-size arrays and hashes 
-- as well as varying-size arrays and hashes.
+- as well as varying-size arrays, hashes and sets.
+- dates, times, datetimes.
 - and many more!
 
-It is common to call `include PropCheck::Generators` in e.g. your testing-suite files to be able to use these.
-If you want to be more explicit (but somewhat more verbose) when calling these functions. feel free to e.g. create a module-alias (like `PG = PropCheck::Generators`) instead.
+It is common and recommended to set up a module alias by using `G = PropCheck::Generators` in e.g. your testing-suite files to be able to refer to all of them.
+_(Earlier versions of the library recommended including the module instead. But this will make it very simple to accidentally shadow a generator with a local variable named `float` or `array` and similar.)_
 
 ### Writing Custom Generators
 
@@ -228,33 +229,37 @@ Always returns the given value. No shrinking.
 
 Allows you to take the result of one generator and transform it into something else.
     
-    >> Generators.choose(32..128).map(&:chr).call(10, Random.new(42))
-    => "S"
+    >> G.choose(32..128).map(&:chr).sample(1, size: 10, Random.new(42))
+    => ["S"]
 
 #### Generator#bind
 
 Allows you to create one or another generator conditionally on the output of another generator.
 
-    >> Generators.integer.bind { |a| Generators.integer.bind { |b| Generator.wrap([a , b]) } }.call(100, Random.new(42))
-    => [2, 79]
+    >> G.integer.bind { |a| G.integer.bind { |b| G.constant([a , b]) } }.sample(1, size: 100, rng: Random.new(42)
+    => [[2, 79]]
 
+This is an advanced feature. Often, you can use a combination of `Generators.tuple` and `Generator#map` instead:
+
+    >> G.tuple(integer, integer).sample(1, size: 100, rng: Random.new(42)
+    => [[2, 79]]
 
 #### Generators.one_of
 
 Useful if you want to be able to generate a value to be one of multiple possibilities:
 
     
-    >> Generators.one_of(Generators.constant(true), Generators.constant(false)).sample(5, size: 10, rng: Random.new(42))
+    >> G.one_of(G.constant(true), G.constant(false)).sample(5, size: 10, rng: Random.new(42))
     => [true, false, true, true, true]
 
-(note that for this example, you can also use `Generators.boolean`. The example happens to show how it is implemented under the hood.)
+(Note that for this example, you can also use `G.boolean`. The example happens to show how it is implemented under the hood.)
 
 #### Generators.frequency
 
 If `one_of` does not give you enough flexibility because you want some results to be more common than others,
 you can use `Generators.frequency` which takes a hash of (integer_frequency => generator) keypairs.
 
-    >> Generators.frequency(5 => Generators.integer, 1 => Generators.printable_ascii_char).sample(size: 10, rng: Random.new(42))
+    >> G.frequency(5 => G.integer, 1 => G.printable_ascii_char).sample(size: 10, rng: Random.new(42))
     => [4, -3, 10, 8, 0, -7, 10, 1, "E", 10]
 
 #### Others

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Before releasing v1.0, we want to finish the following:
 - [x] Before/after/around hooks to add setup/teardown logic to be called before/after/around each time a check is run with new data.
 - [x] Possibility to resize generators.
 - [x] `#instance` generator to allow the easy creation of generators for custom datatypes.
-- [ ] A usage guide.
-- [ ] A simple way to create recursive generators
 - [x] Builtin generation of `Set`s
 - [x] Builtin generation of `Date`s, `Time`s and `DateTime`s.
-- [ ] Configuration option to resize all generators given to a particular Property instance.
+- [x] Configuration option to resize all generators given to a particular Property instance.
+- [ ] A simple way to create recursive generators
+- [ ] A usage guide.
 
 ## Nice-to-haves
  

--- a/lib/prop_check/property.rb
+++ b/lib/prop_check/property.rb
@@ -111,6 +111,36 @@ module PropCheck
       duplicate
     end
 
+    def growing_exponentially
+      orig_fun = @config.resize_function
+      fun = proc { |size| 2.pow(orig_fun(size)) }
+      with_config(resize_function: fun)
+    end
+
+    def growing_quadratically
+      orig_fun = @config.resize_function
+      fun = proc { |size| orig_fun(size).pow(2) }
+      with_config(resize_function: fun)
+    end
+
+    def growing_fast
+      growth_fun = @config.resize_function
+      fun = proc { |size| growth_fun(size) * 2 }
+      with_config(resize_function: fun)
+    end
+
+    def growing_slow
+      growth_fun = @config.resize_function
+      fun = proc { |size| growth_fun(size) * 0.5 }
+      with_config(resize_function: fun)
+    end
+
+    def growing_logarithmically
+      orig_fun = @config.resize_function
+      fun = proc { |size| Math.log2(orig_fun(size)).to_i }
+      with_config(resize_function: fun)
+    end
+
     def with_bindings(*bindings, **kwbindings)
       raise ArgumentError, 'No bindings specified!' if bindings.empty? && kwbindings.empty?
 
@@ -280,7 +310,7 @@ c.f. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-k
         .lazy
         .map do
         binding_generator.generate(
-          size: size,
+          size: @config.resize_function.call(size),
           rng: rng,
           max_consecutive_attempts: @config.max_consecutive_attempts,
           config: @config

--- a/lib/prop_check/property.rb
+++ b/lib/prop_check/property.rb
@@ -111,34 +111,65 @@ module PropCheck
       duplicate
     end
 
-    def growing_exponentially
+    ##
+    # Resizes all generators in this property with the given function.
+    #
+    # Shorthand for manually wrapping `PropCheck::Property::Configuration.resize_function` with the new function.
+    def resize(&block)
+      raise '#resize called without a block' unless block_given?
+
       orig_fun = @config.resize_function
-      fun = proc { |size| 2.pow(orig_fun(size)) }
-      with_config(resize_function: fun)
+      with_config(resize_function: block)
     end
 
-    def growing_quadratically
+    ##
+    # Resizes all generators in this property. The new size is `2.pow(orig_size)`
+    #
+    # c.f. #resize
+    def growing_exponentially(&block)
       orig_fun = @config.resize_function
-      fun = proc { |size| orig_fun(size).pow(2) }
-      with_config(resize_function: fun)
+      fun = proc { |size| 2.pow(orig_fun.call(size)) }
+      with_config(resize_function: fun, &block)
     end
 
-    def growing_fast
-      growth_fun = @config.resize_function
-      fun = proc { |size| growth_fun(size) * 2 }
-      with_config(resize_function: fun)
-    end
-
-    def growing_slow
-      growth_fun = @config.resize_function
-      fun = proc { |size| growth_fun(size) * 0.5 }
-      with_config(resize_function: fun)
-    end
-
-    def growing_logarithmically
+    ##
+    # Resizes all generators in this property. The new size is `orig_size * orig_size`
+    #
+    # c.f. #resize
+    def growing_quadratically(&block)
       orig_fun = @config.resize_function
-      fun = proc { |size| Math.log2(orig_fun(size)).to_i }
-      with_config(resize_function: fun)
+      fun = proc { |size| orig_fun.call(size).pow(2) }
+      with_config(resize_function: fun, &block)
+    end
+
+    ##
+    # Resizes all generators in this property. The new size is `2 * orig_size`
+    #
+    # c.f. #resize
+    def growing_fast(&block)
+      orig_fun = @config.resize_function
+      fun = proc { |size| orig_fun.call(size) * 2 }
+      with_config(resize_function: fun, &block)
+    end
+
+    ##
+    # Resizes all generators in this property. The new size is `0.5 * orig_size`
+    #
+    # c.f. #resize
+    def growing_slowly(&block)
+      orig_fun = @config.resize_function
+      fun = proc { |size| orig_fun.call(size) * 0.5 }
+      with_config(resize_function: fun, &block)
+    end
+
+    ##
+    # Resizes all generators in this property. The new size is `Math.log2(orig_size)`
+    #
+    # c.f. #resize
+    def growing_logarithmically(&block)
+      orig_fun = @config.resize_function
+      fun = proc { |size| Math.log2(orig_fun.call(size)) }
+      with_config(resize_function: fun, &block)
     end
 
     def with_bindings(*bindings, **kwbindings)
@@ -309,8 +340,9 @@ c.f. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-k
       (0...@config.max_generate_attempts)
         .lazy
         .map do
+        generator_size = @config.resize_function.call(size).to_i
         binding_generator.generate(
-          size: @config.resize_function.call(size),
+          size: generator_size,
           rng: rng,
           max_consecutive_attempts: @config.max_consecutive_attempts,
           config: @config

--- a/lib/prop_check/property/configuration.rb
+++ b/lib/prop_check/property/configuration.rb
@@ -18,6 +18,9 @@ module PropCheck
     # - `default_epoch:` The 'base' value to use for date/time generators like
     #    `PropCheck::Generators#date` `PropCheck::Generators#future_date` `PropCheck::Generators#time`, etc.
     #    (Default: `DateTime.now`)
+    # - `resize_function` A proc that can be used to resize _all_ generators.
+    #    Takes the current size as integer and should return a new integer.
+    #   (Default: `proc { |size| size }`)
     Configuration = Struct.new(
       :verbose,
       :n_runs,
@@ -25,6 +28,7 @@ module PropCheck
       :max_shrink_steps,
       :max_consecutive_attempts,
       :default_epoch,
+      :resize_function,
       keyword_init: true
     ) do
       def initialize(
@@ -33,7 +37,8 @@ module PropCheck
         max_generate_attempts: 10_000,
         max_shrink_steps: 10_000,
         max_consecutive_attempts: 30,
-        default_epoch: DateTime.now
+        default_epoch: DateTime.now,
+        resize_function: proc { |size| size }
       )
         super
       end

--- a/lib/prop_check/version.rb
+++ b/lib/prop_check/version.rb
@@ -1,3 +1,3 @@
 module PropCheck
-  VERSION = '0.15.0'
+  VERSION = '0.16.0'
 end

--- a/spec/prop_check_spec.rb
+++ b/spec/prop_check_spec.rb
@@ -1,19 +1,19 @@
 RSpec.describe PropCheck do
-  it "has a version number" do
+  it 'has a version number' do
     expect(PropCheck::VERSION).not_to be nil
   end
 
   describe PropCheck do
-    describe ".forall" do
-      it "returns a Property when called without a block" do
+    describe '.forall' do
+      it 'returns a Property when called without a block' do
         expect(PropCheck.forall(x: PropCheck::Generators.integer)).to be_a(PropCheck::Property)
       end
 
-      it "runs the property test when called with a block" do
+      it 'runs the property test when called with a block' do
         expect { |block| PropCheck.forall(x: PropCheck::Generators.integer, &block) }.to yield_control
       end
 
-      it "accepts simple arguments" do
+      it 'accepts simple arguments' do
         expect do
           PropCheck.forall(PropCheck::Generators.integer, PropCheck::Generators.float) do |x, y|
             expect(x).to be_a Integer
@@ -22,7 +22,7 @@ RSpec.describe PropCheck do
         end.not_to raise_error
       end
 
-      it "accepts keyword arguments" do
+      it 'accepts keyword arguments' do
         expect do
           PropCheck.forall(x: PropCheck::Generators.integer, y: PropCheck::Generators.float) do |x:, y:|
             expect(x).to be_a Integer
@@ -31,7 +31,7 @@ RSpec.describe PropCheck do
         end.not_to raise_error
       end
 
-      it "raises when receiving both simple and keyword arguments at the same time" do
+      it 'raises when receiving both simple and keyword arguments at the same time' do
         expect do
           PropCheck.forall(PropCheck::Generators.integer, a: PropCheck::Generators.integer) do |int, hash|
             expect(int).to be_a Integer
@@ -40,7 +40,7 @@ RSpec.describe PropCheck do
         end.to raise_error(ArgumentError)
       end
 
-      it "will not shrink upon encountering a SystemExit" do
+      it 'will not shrink upon encountering a SystemExit' do
         expect do
           PropCheck.forall(x: PropCheck::Generators.integer) do |x:|
             raise SystemExit if x > 3
@@ -53,10 +53,10 @@ RSpec.describe PropCheck do
         end
       end
 
-      it "will not shrink upon encountering a SignalException" do
+      it 'will not shrink upon encountering a SignalException' do
         expect do
           PropCheck.forall(x: PropCheck::Generators.integer) do |x:|
-            Process.kill('HUP',Process.pid) if x > 3
+            Process.kill('HUP', Process.pid) if x > 3
           end
         end.to raise_error do |error|
           expect(error).to be_a(SignalException)
@@ -66,10 +66,10 @@ RSpec.describe PropCheck do
         end
       end
 
-      it "shrinks and returns an exception with the #prop_check_info method upon finding a failure case" do
-
+      it 'shrinks and returns an exception with the #prop_check_info method upon finding a failure case' do
         class MyCustomError < StandardError; end
-        expected_keys = [:original_input, :original_exception_message, :shrunken_input, :shrunken_exception, :n_successful, :n_shrink_steps]
+        expected_keys = %i[original_input original_exception_message shrunken_input shrunken_exception
+                           n_successful n_shrink_steps]
         exploding_val = nil
         shrunken_val = nil
 
@@ -78,38 +78,40 @@ RSpec.describe PropCheck do
             if x > 3.1415
               exploding_val ||= x
               shrunken_val = x
-              raise MyCustomError, "I do not like this number"
+              raise MyCustomError, 'I do not like this number'
             end
           end
         end.to raise_error do |error|
           expect(error).to be_a(MyCustomError)
-          expect(defined?(error.prop_check_info)).to eq("method")
+          expect(defined?(error.prop_check_info)).to eq('method')
           info = error.prop_check_info
           expect(info.keys).to contain_exactly(*expected_keys)
 
-          expect(info[:original_exception_message]).to eq("I do not like this number")
-          expect(info[:original_input]).to eq({x: exploding_val})
-          expect(info[:shrunken_input]).to eq({x: shrunken_val})
+          expect(info[:original_exception_message]).to eq('I do not like this number')
+          expect(info[:original_input]).to eq({ x: exploding_val })
+          expect(info[:shrunken_input]).to eq({ x: shrunken_val })
           expect(info[:n_successful]).to be_a(Integer)
           expect(info[:n_shrink_steps]).to be_a(Integer)
         end
       end
     end
 
-    describe "Property" do
-      describe "#with_config" do
-        it "updates the configuration" do
+    describe 'Property' do
+      describe '#with_config' do
+        it 'updates the configuration' do
           p = PropCheck.forall(x: PropCheck::Generators.integer)
           expect(p.configuration[:verbose]).to be false
           expect(p.with_config(verbose: true).configuration[:verbose]).to be true
         end
-        it "Runs the property test when called with a block" do
-          expect { |block| PropCheck.forall(x: PropCheck::Generators.integer).with_config(**{}, &block) }.to yield_control
+        it 'Runs the property test when called with a block' do
+          expect do |block|
+            PropCheck.forall(x: PropCheck::Generators.integer).with_config(**{}, &block)
+          end.to yield_control
         end
       end
 
-      describe "#check" do
-        it "generates an error that Rspec can pick up" do
+      describe '#check' do
+        it 'generates an error that Rspec can pick up' do
           expect do
             PropCheck.forall(x: PropCheck::Generators.nonnegative_integer).with_config(n_runs: 1_000) do |x:|
               expect(x).to be < 10
@@ -123,11 +125,10 @@ RSpec.describe PropCheck do
             expect(error.message).to match(/Shrunken input \(after \d+ shrink steps\):/m)
             expect(error.message).to match(/Shrunken exception:/m)
 
-            expect(defined?(error.prop_check_info)).to eq("method")
+            expect(defined?(error.prop_check_info)).to eq('method')
             # p error.prop_check_info
           end
         end
-
 
         it "generates an error with 'shrinking impossible' if the value cannot be shrunk further" do
           srand(42)
@@ -142,16 +143,19 @@ RSpec.describe PropCheck do
         end
       end
 
-      describe "#where" do
-        it "filters results" do
-          PropCheck.forall(x: PropCheck::Generators.integer, y: PropCheck::Generators.positive_integer).where { |x:, y:|  x != y}.check do |x:, y:|
+      describe '#where' do
+        it 'filters results' do
+          PropCheck.forall(x: PropCheck::Generators.integer,
+                           y: PropCheck::Generators.positive_integer).where do |x:, y:|
+            x != y
+          end.check do |x:, y:|
             expect(x).to_not eq y
           end
         end
 
-        it "raises an error if too much was filtered" do
+        it 'raises an error if too much was filtered' do
           expect do
-            PropCheck.forall(x: PropCheck::Generators.positive_integer).where { |x:|  x == 0}.check do
+            PropCheck.forall(x: PropCheck::Generators.positive_integer).where { |x:| x == 0 }.check do
             end
           end.to raise_error do |error|
             expect(error).to be_a(PropCheck::Errors::GeneratorExhaustedError)
@@ -160,9 +164,9 @@ RSpec.describe PropCheck do
           end
         end
 
-        it "crashes when doing nonesense in the where block" do
+        it 'crashes when doing nonesense in the where block' do
           expect do
-            PropCheck.forall(x: PropCheck::Generators.negative_integer).where { |x:|  x.unexistentmethod == 3}.check do
+            PropCheck.forall(x: PropCheck::Generators.negative_integer).where { |x:| x.unexistentmethod == 3 }.check do
             end
           end.to raise_error do |error|
             expect(error).to be_a(NoMethodError)
@@ -172,63 +176,60 @@ RSpec.describe PropCheck do
         end
       end
 
-      describe ".configure" do
-        it "configures all checks done from that point onward" do
+      describe '.configure' do
+        it 'configures all checks done from that point onward' do
           PropCheck::Property.configure do |config|
             config.n_runs = 42
           end
 
-          expect(PropCheck::forall(foo: PropCheck::Generators.integer).configuration.n_runs).to be 42
+          expect(PropCheck.forall(foo: PropCheck::Generators.integer).configuration.n_runs).to be 42
         end
       end
-      describe "hooks" do
-
-        describe "#before" do
-          it "calls the before block before every generated value (even filtered ones)" do
+      describe 'hooks' do
+        describe '#before' do
+          it 'calls the before block before every generated value (even filtered ones)' do
             expect do |before_hook|
               PropCheck.forall(PropCheck::Generators.integer)
-                .with_config(n_runs: 100)
-                .before(&before_hook)
-                .where { |x| x.odd? }
-                .check do
+                       .with_config(n_runs: 100)
+                       .before(&before_hook)
+                       .where { |x| x.odd? }
+                       .check do
               end
             end.to yield_control.exactly(100).times
           end
         end
 
-        describe "#after" do
-          it "calls the after block after every generated value (even filtered ones)" do
+        describe '#after' do
+          it 'calls the after block after every generated value (even filtered ones)' do
             expect do |after_hook|
               PropCheck.forall(PropCheck::Generators.integer)
-                .with_config(n_runs: 100)
-                .after(&after_hook)
-                .where { |x| x.even? }
-                .check do
+                       .with_config(n_runs: 100)
+                       .after(&after_hook)
+                       .where { |x| x.even? }
+                       .check do
               end
             end.to yield_control.exactly(100).times
           end
         end
 
-        describe "#around" do
-          it "calls the around block around every generated value (even filtered ones)" do
+        describe '#around' do
+          it 'calls the around block around every generated value (even filtered ones)' do
             before_calls = 0
             after_calls = 0
             inner_calls = 0
             around_hook = proc do |&block|
-              begin
-                before_calls += 1
-                block.call
-              ensure
-                after_calls += 1
-              end
+              before_calls += 1
+              block.call
+            ensure
+              after_calls += 1
             end
             PropCheck.forall(PropCheck::Generators.integer)
-              .with_config(n_runs: 100)
-              .around(&around_hook)
-              .where { |x| x.odd? }
-              .check do
-                inner_calls += 1
-              end
+                     .with_config(n_runs: 100)
+                     .around(&around_hook)
+                     .where { |x| x.odd? }
+                     .check do
+              inner_calls += 1
+            end
             expect(before_calls).to eq(100)
             expect(after_calls).to eq(100)
             expect(inner_calls).to eq(100)
@@ -237,10 +238,10 @@ RSpec.describe PropCheck do
       end
     end
 
-    describe "including PropCheck in a testing-environment" do
+    describe 'including PropCheck in a testing-environment' do
       include PropCheck
       include PropCheck::Generators
-      it "adds forall to the example scope and brings generators inside PropCheck::Generators into scope`" do
+      it 'adds forall to the example scope and brings generators inside PropCheck::Generators into scope`' do
         thing = nil
         forall(x: integer) do |x:|
           expect(x).to be_a(Integer)
@@ -256,6 +257,16 @@ RSpec.describe PropCheck do
       it 'does not fail wenn calling call_splatted' do
         PropCheck.forall(hash_of(string, integer)) do |h|
           expect(h).to be_a(Hash)
+        end
+      end
+    end
+
+    describe 'resizing' do
+      include PropCheck::Generators
+
+      it 'will not find a counter-example if resized to logarithmically while iterating only 100 times' do
+        PropCheck.forall(integer).growing_logarithmically do |val|
+          expect(val).to be < 6
         end
       end
     end


### PR DESCRIPTION
- New option in `PropCheck::Property::Configuration` to resize all generators at once.
- Wrapper functions to modify this easily in `PropCheck::Property` called `#resize`, `#grow_fast`, `#grow_slowly`, `#grow_exponentially`, `#grow_quadratically`, `#grow_logarithmically`.
