### PR TITLE
Add support for Ruby 3.2

### DIFF
--- a/lib/prop_check/property.rb
+++ b/lib/prop_check/property.rb
@@ -332,7 +332,7 @@ c.f. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-k
     end
 
     private def raw_attempts_enum(binding_generator)
-      rng = Random::DEFAULT
+      rng = Random.new
       size = 1
       (0...@config.max_generate_attempts)
         .lazy


### PR DESCRIPTION
`Random::DEFAULT` seems to be deprecated in Ruby 3.2. I simply replaced it with `Random.new` and my specs worked. I am not sure, if this is the correct solution. Please investigate before merging.