### PR TITLE
fix negative_float RDoc comment

### DIFF
--- a/lib/prop_check/generators.rb
+++ b/lib/prop_check/generators.rb
@@ -266,7 +266,7 @@ module PropCheck
     end
 
     ##
-    # Generates positive floating point numbers
+    # Generates negative floating point numbers
     # Will generate special floats (except NaN) from time to time.
     # c.f. #float
     def negative_float


### PR DESCRIPTION
`#negative_float` generates **negative** floating point numbers.

I'm assuming this change will also fix the [documentation](https://www.rubydoc.info/github/Qqwy/ruby-prop_check/master/PropCheck%2FGenerators%2Enegative_float).