### PR TITLE
Add test-unit sample to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ class NaiveAverageTest < MiniTest::Unit::TestCase
 end
 ```
 
+The test case, using test-unit:
+``` ruby
+require "test-unit"
+
+class TestNaiveAverage < Test::Unit::TestCase
+  G = PropCheck::Generators
+
+  def test_that_it_returns_an_integer_for_any_input
+    PropCheck.forall(G.array(G.integer)) do |numbers|
+      result = naive_average(numbers)
+
+      assert_instance_of(Integer, result)
+    end
+  end
+end
+```
+
 The test case, using only vanilla Ruby:
 ```ruby
 # And then in a test case:
@@ -309,7 +326,7 @@ Here are some simple recommendations for the best results:
                .check(&block)
   end
 ```
-- Other setup/cleanup should also usually happen around each generated example rather than around the whole test: Instead of using the hooks exposed by RSpec/MiniTest/etc., use the before/after/around hooks exposed by PropCheck.
+- Other setup/cleanup should also usually happen around each generated example rather than around the whole test: Instead of using the hooks exposed by RSpec/MiniTest/test-unit/etc., use the before/after/around hooks exposed by PropCheck.
 
 ## Development
 


### PR DESCRIPTION
There is three popular testing framework on Ruby: RSpec, MiniTest, unit-test.
For example, `bundle gem` command has `-t` option to prefer test framework in the above.
https://bundler.io/v2.4/man/bundle-gem.1.html

So, it is useful to add unit-test sample to README.

This sample has been ensured to work correctly by https://gist.github.com/niku/6dec8e397943cdc372b969fff26299e7#file-readme-md.
