### PR TITLE
Get rid of `awesome_print` by simply using the built-in `PP` module. And release v1.0!

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -15,8 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # NOTE: Ruby 3.2 is not in here, as `doctest-core` first needs to be updated to support it
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        # NOTE: We're stopping testing Ruby < 3.0 since prop_check version 1.0.0
+        # It will _probably_ still work but as they're end-of-life, no guarantees!
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+- 1.0.0
+  - Changes:
+    - Pretty-print failures using Ruby's builtin `PP`, so `prop_check` no longer depends on the `awesome_print` gem. (c.f. #19)
 - 0.18.2
   - Documentation updates:
-    - PR #18: Adding an example of using prop_check with the `test-unit` testing framework to the README. Thank you, @niku!
-    - PR #17, #18, #21: fixing typos in various parts of the documentation. Thank you, @meganemura, @niku and @harlantwood!
+    - Adding an example of using prop_check with the `test-unit` testing framework to the README. (c.f. #18, thank you, @niku!)
+    - Fixing typos in various parts of the documentation.  (c.f. #16, #17, #21. Thank you, @meganemura, @niku and @harlantwood!)
 - 0.18.1
   - Fixes:
     - Compatibility with Ruby 3.2:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It features:
 - Shrinking to a minimal counter-example on failure.
 - Hooks to perform extra set-up/cleanup logic before/after every example case.
 
+It requires _no_ external dependencies, and integrates well with all common test frameworks (see below).
+
 ## What is PropCheck?
 
 PropCheck is a Ruby library to create unit tests which are simpler to write and more powerful when run, finding edge-cases in your code you wouldn't have thought to look for.
@@ -218,16 +220,15 @@ For instance, when a failure happens with the input `x = 100`,
 PropCheck will see if the failure still happens with `x = 50`.
 If it does , it will try `x = 25`. If not, it will try `x = 75`, and so on.
 
-This means if something only goes wrong for `x = 2`, the program will try:
+This means for example that if something only goes for wrong for `x >= 8`, the program will try:
 - `x = 100`(fails),
 - `x = 50`(fails), 
 - `x = 25`(fails), 
 - `x = 12`(fails), 
-- `x = 6`(fails), 
-- `x = 3`(fails), 
-- `x = 1` (succeeds), `x = 2` (fails).
+- `x = 6`(succeeds), `x = 9` (fails)
+- `x = 7`(succeeds), `x = 8` (fails).
 
-and thus the simplified case of `x = 2` is shown in the output.
+and thus the simplified case of `x = 8` is shown in the output.
 
 The documentation of the provided generators explain how they shrink.
 A short summary:

--- a/lib/prop_check/property.rb
+++ b/lib/prop_check/property.rb
@@ -1,5 +1,4 @@
 require 'stringio'
-require 'amazing_print'
 
 require 'prop_check/property/configuration'
 require 'prop_check/property/output_formatter'

--- a/lib/prop_check/property/output_formatter.rb
+++ b/lib/prop_check/property/output_formatter.rb
@@ -1,5 +1,7 @@
 ##
 # @api private
+require 'pp'
+
 module PropCheck::Property::OutputFormatter
   extend self
 
@@ -32,10 +34,13 @@ module PropCheck::Property::OutputFormatter
   end
 
   def print_roots(lazy_tree_val)
-    if lazy_tree_val.is_a?(Array) && lazy_tree_val.length == 1 && lazy_tree_val[0].is_a?(Hash)
-      lazy_tree_val[0].ai
-    else
-      lazy_tree_val.ai
-    end
+    data =
+      if lazy_tree_val.is_a?(Array) && lazy_tree_val.length == 1 && lazy_tree_val[0].is_a?(Hash)
+        lazy_tree_val[0].pp
+      else
+        lazy_tree_val
+      end
+
+    PP.pp(data, '')
   end
 end

--- a/lib/prop_check/property/output_formatter.rb
+++ b/lib/prop_check/property/output_formatter.rb
@@ -36,7 +36,7 @@ module PropCheck::Property::OutputFormatter
   def print_roots(lazy_tree_val)
     data =
       if lazy_tree_val.is_a?(Array) && lazy_tree_val.length == 1 && lazy_tree_val[0].is_a?(Hash)
-        lazy_tree_val[0].pp
+        lazy_tree_val[0]
       else
         lazy_tree_val
       end

--- a/lib/prop_check/version.rb
+++ b/lib/prop_check/version.rb
@@ -1,3 +1,3 @@
 module PropCheck
-  VERSION = '0.18.2'
+  VERSION = '1.0.0'
 end

--- a/prop_check.gemspec
+++ b/prop_check.gemspec
@@ -35,6 +35,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.5.1'
-
-  spec.add_dependency 'amazing_print', '~> 1.2'
 end

--- a/prop_check.gemspec
+++ b/prop_check.gemspec
@@ -6,7 +6,7 @@ require "prop_check/version"
 Gem::Specification.new do |spec|
   spec.name          = "prop_check"
   spec.version       = PropCheck::VERSION
-  spec.authors       = ["Qqwy/Wiebe-Marten Wijnja"]
+  spec.authors       = ["Qqwy/Marten Wijnja"]
   spec.email         = ["w-m@wmcode.nl"]
 
   spec.summary       = %q{PropCheck allows you to do property-based testing, including shrinking.}


### PR DESCRIPTION
- [x] This PR gets rid of the `awesome_print` dependency by simply using the built-in `PP` module to do pretty-printing instead. 
- [x] There've also been some small clarifications to the README.
- [x] And CI no longer tries to test Ruby versions < 3.0, as installing them on CI no longer seems possible. The gemspec sill mentions that any Ruby starting from v2.5 should work (and it _should_, but as Ruby 2 is end-of-life, it's at your own responsibility).
- [x] And finally bump the version to  v1.0!


Fixes #19 