### PR TITLE
Simplify merging process

### DIFF
--- a/lib/prop_check/generator.rb
+++ b/lib/prop_check/generator.rb
@@ -55,7 +55,7 @@ module PropCheck
     #   >> Generators.integer.call(size: 1000, rng: Random.new(42))
     #   => 126
     def call(**kwargs)
-      generate(**@@default_kwargs.merge(kwargs)).root
+      generate(**kwargs).root
     end
 
     ##
@@ -63,7 +63,7 @@ module PropCheck
     # This is mostly useful for debugging if a generator behaves as you intend it to.
     def sample(num_of_samples = 10, **kwargs)
       num_of_samples.times.map do
-        call(**@@default_kwargs.merge(kwargs))
+        call(**kwargs)
       end
     end
 


### PR DESCRIPTION
Remove unnecessary merges Merging the `kwargs` with the `@@default_kwargs` is needed only once before calling the `@block`.

The method `sample` calls the method `call`, and the method `call` calls the method `generate`.
Therefore, when merge processing is performed only at the `generate`, the merging processing will be executed only once by the `sample` and the `call`.