### PR TITLE
Update version of GH action 'ruby-setup'

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -24,8 +24,7 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@0a29871fe2b0200a17a4497bae54fe5df0d973aa # v1.115.3
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # NOTE: We're stopping testing Ruby < 3.0 since prop_check version 1.0.0
         # It will _probably_ still work but as they're end-of-life, no guarantees!
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- [x] Updates the CI dependencies to modern versions.
- [x] Run against Ruby 3.3
- [x] Run against Ruby 3.4

Fixes #27 